### PR TITLE
fix: item_dict returns empty stanzas

### DIFF
--- a/addonfactory_splunk_conf_parser_lib.py
+++ b/addonfactory_splunk_conf_parser_lib.py
@@ -227,6 +227,5 @@ class TABConfigParser(configparser.RawConfigParser):
                 ):
                     continue
                 kv[k] = v
-            if kv:
-                res[section] = kv
+            res[section] = kv
         return res

--- a/test_addonfactory_splunk_conf_parser_lib.py
+++ b/test_addonfactory_splunk_conf_parser_lib.py
@@ -163,6 +163,41 @@ tag2 = enabled
         }
         self.assertEqual(expected_item_dict, parser.item_dict())
 
+    def test_item_dict_when_there_is_empty_stanza(self):
+        conf = """
+[stanza_with_something]
+key = value
+
+[empty_stanza]
+"""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        expected_item_dict = {
+            "stanza_with_something": {
+                "key": "value",
+            },
+            "empty_stanza": {},
+        }
+        self.assertEqual(expected_item_dict, parser.item_dict())
+
+    def test_item_dict_when_there_is_empty_stanza_and_comment(self):
+        conf = """
+[stanza_with_something]
+key = value
+
+[empty_stanza]
+# This is a comment
+"""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        expected_item_dict = {
+            "stanza_with_something": {
+                "key": "value",
+            },
+            "empty_stanza": {},
+        }
+        self.assertEqual(expected_item_dict, parser.item_dict())
+
     def test_remove_existing_section(self):
         conf = """
 # Comment


### PR DESCRIPTION
This fix is a result of migrating from splunk-appinspect to this library in pytest-splunk-addon.

Reference PR: https://github.com/splunk/pytest-splunk-addon/pull/464

Closes #36.