### PR TITLE
fix: check before truncating new line

### DIFF
--- a/addonfactory_splunk_conf_parser_lib.py
+++ b/addonfactory_splunk_conf_parser_lib.py
@@ -155,7 +155,8 @@ class TABConfigParser(configparser.RawConfigParser):
                 if isinstance(val, list):
                     options[name] = "\n".join(val)
 
-    # As the type of fp is not defined in RawConfigParser which is the parent class so we have to go with Any.
+    # As the type of `fp` is not defined in RawConfigParser (parent class)
+    # we define the type of `fp` as Any
     def write(self, fp: Any, *args) -> None:
         """
         Override the write() method to write comments
@@ -193,9 +194,12 @@ class TABConfigParser(configparser.RawConfigParser):
             # write the separator line for stanza
             fp.write("\n")
 
-        # remove the trailing lines in a file, as the content should be written as-is
-        fp.seek(fp.tell() - 1, SEEK_SET)
-        fp.truncate()
+        # multiple lines are added when there are stanzas/sections and its properties,
+        # hence we check if there are stanzas/sections before truncating the trailing newline
+        if self._defaults or self._sections:
+            # remove the trailing lines in a file, as the content should be written as-is
+            fp.seek(fp.tell() - 1, SEEK_SET)
+            fp.truncate()
 
     def optionxform(self, optionstr):
         return optionstr

--- a/test_addonfactory_splunk_conf_parser_lib.py
+++ b/test_addonfactory_splunk_conf_parser_lib.py
@@ -85,6 +85,54 @@ tag = enabled
         parser.write(output)
         self.assertEqual(conf, output.getvalue())
 
+    def test_write_empty(self):
+        conf = ""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        output = io.StringIO()
+        parser.write(output)
+        self.assertEqual(conf, output.getvalue())
+
+    def test_write_only_comments(self):
+        conf = """
+#
+# some comment here
+#
+"""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        output = io.StringIO()
+        parser.write(output)
+        self.assertEqual(conf, output.getvalue())
+
+    def test_write_only_default_section(self):
+        conf = """
+#
+# some comment here
+#
+[DEFAULT]
+attrib_one = value_one
+attrib_two = value_two
+"""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        output = io.StringIO()
+        parser.write(output)
+        self.assertEqual(conf, output.getvalue())
+
+    def test_write_fields_outside(self):
+        conf = """
+#
+#
+out_field = out_value
+out_field_two = out_value_two
+"""
+        parser = conf_parser.TABConfigParser()
+        parser.read_string(conf)
+        output = io.StringIO()
+        parser.write(output)
+        self.assertEqual(conf, output.getvalue())
+
     def test_items(self):
         conf = """
 #


### PR DESCRIPTION
**Fix:** updated the logic to remove duplicate newlines only when there is content (default stanzas and others) as they are adding two new lines.
**Test:** added test cases for all the scenarios based on the `write()` function.