### PR TITLE
ci: fix ubuntu version to 22.04

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -28,7 +28,7 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -37,7 +37,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   test-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
@@ -68,7 +68,7 @@ jobs:
       - compliance-copyrights
       - pre-commit
       - test-unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -28,12 +28,12 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1
 
   test-unit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
     -   id: mypy
         exclude: ^docs/
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
     -   id: flake8


### PR DESCRIPTION
This PR sets ubuntu version to 22.04 for scripts run with python 3.7.
Reference: [ADDON-75861](https://splunk.atlassian.net/browse/ADDON-75861)