### PR TITLE
ci: migrate GH_TOKEN_ADMIN to GitHub App token

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -74,6 +74,13 @@ jobs:
           # Very important: semantic-release won't trigger a tagged
           # build if this is not set false
           persist-credentials: false
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
@@ -91,7 +98,7 @@ jobs:
           extra_plugins: |
             semantic-release-replace-plugin
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
         run: |
           poetry build


### PR DESCRIPTION
## Summary
- Replace the long-lived `GH_TOKEN_ADMIN` PAT with a short-lived GitHub App installation token via `actions/create-github-app-token@v3` in the publish job.
- The app token is scoped to the org installation and used for the semantic-release step.

Made with [Cursor](https://cursor.com)